### PR TITLE
If syncProvder is set but does not return time, subsequent calls to now() should try to sync.

### DIFF
--- a/Time.cpp
+++ b/Time.cpp
@@ -248,9 +248,9 @@ time_t sysUnsyncedTime = 0; // the time sysTime unadjusted by sync
 
 
 time_t now() {
-	// calculate number of seconds passed since last call to now()
+  // calculate number of seconds passed since last call to now()
   while (millis() - prevMillis >= 1000) {
-		// millis() and prevMillis are both unsigned ints thus the subtraction will always be the absolute value of the difference
+    // millis() and prevMillis are both unsigned ints thus the subtraction will always be the absolute value of the difference
     sysTime++;
     prevMillis += 1000;	
 #ifdef TIME_DRIFT_INFO
@@ -262,9 +262,13 @@ time_t now() {
       time_t t = getTimePtr();
       if (t != 0) {
         setTime(t);
+      } else if(timeNotSet == Status) {
+        // getTimePtr returned 0 and time has not yet been set, i.e. this was not
+        // a temporarily failure, we have not been able to sync at all.
+        // Do nothing so a new attempt to sync will be made next time now() is called.
       } else {
         nextSyncTime = sysTime + syncInterval;
-        Status = (Status == timeNotSet) ?  timeNotSet : timeNeedsSync;
+        Status = timeNeedsSync;
       }
     }
   }  


### PR DESCRIPTION
I use a GSM modem to sync my time. When I initialise my program I call setSyncProvider to set my getTImeFunction. Though at that time the modem is not turned on neither has it connected to the mobile network and thus the sync attempt in now() will fail. But subsequent calls after I have taken the modem online will return a none synced time even if the sync service is available. Once syncInterval has passed now() will make a new sync attempt.

Instead I would like now() to try to sync everytime as long as the status is timeNotSet. The provided code takes care of this.

Also changed the indentation to spaces instead of tabs of my previous commit.