### PR TITLE
Make it possible to specify a sync provider with a parameter

### DIFF
--- a/Time.h
+++ b/Time.h
@@ -58,7 +58,8 @@ typedef struct  {
 #define  tmYearToY2k(Y)      ((Y) - 30)    // offset is from 2000
 #define  y2kYearToTm(Y)      ((Y) + 30)   
 
-typedef time_t(*getExternalTime)();
+typedef time_t(*getExternalTime)(); // Old style sync callback
+typedef time_t(*getExternalTimeEx)(void *userParm); // New style sync callback
 //typedef void  (*setExternalTime)(const time_t); // not used in this version
 
 
@@ -132,6 +133,7 @@ char* dayShortStr(uint8_t day);
 /* time sync functions	*/
 timeStatus_t timeStatus(); // indicates if time has been set and recently synchronized
 void    setSyncProvider( getExternalTime getTimeFunction); // identify the external time provider
+void    setSyncProvider( getExternalTimeEx getTimeFunction, void *userParm); // identify the external time provider
 void    setSyncInterval(time_t interval); // set the number of seconds between re-sync
 
 /* low level functions to convert to and from system time                     */


### PR DESCRIPTION
I added some code to the Time library to make it possible to set a sync provider callback function that takes a void pointer parameter. There is some copy-paste code here because I wanted to make my change compatible with existing code that uses a sync provider that doesn't have a parameter.

Example:

    class MyTimeProvider
    {
    public:
      time_t timezone;
    
      time_t get_UTC_from_device(void);
    
      static time_t ProvideSync(void *p)
      {
        MyTimeProvider *timeprovider = (MyTimeProvider*)p;
    
        return p->get_UTC_from_device() + p->timezone;
      }
    
      void MakeMeSyncProvider(void)
      {
        setSyncProvider(ProvideSync, this);
      }
    };

If both a sync-provider-with-parameter and a sync-provider-without-parameter are set, the one without the parameter is ignored. If you want to _cancel_ a syncprovider-with-parameter, make sure you call setSyncProvider(NULL, NULL) instead of setSyncProvider(NULL).

Thanks for considering!