### PR TITLE
Modify `getExternalTime()` typedef for ESP8266 platform

### DIFF
--- a/TimeLib.h
+++ b/TimeLib.h
@@ -58,7 +58,12 @@ typedef struct  {
 #define  tmYearToY2k(Y)      ((Y) - 30)    // offset is from 2000
 #define  y2kYearToTm(Y)      ((Y) + 30)   
 
+#ifdef ARDUINO_ARCH_ESP8266
+#include <functional>
+typedef std::function<time_t(void)> getExternalTime;
+#else
 typedef time_t(*getExternalTime)();
+#endif
 //typedef void  (*setExternalTime)(const time_t); // not used in this version
 
 


### PR DESCRIPTION
Having this change does not modify library interface but enables the possibility to use class member methods as callback with the help of `std::bind()`.
Unfortunately I've not found a way to do the same with Arduino platform, so I've filtered it using preprocessor.
