### PR TITLE
Fixed function weekday(), sunday now returns 0 instead of 1

### DIFF
--- a/Time.cpp
+++ b/Time.cpp
@@ -112,7 +112,7 @@ int day(time_t t) { // the day for the given time (0-6)
   return tm.Day;
 }
 
-int weekday() {   // Sunday is day 1
+int weekday() {   // Sunday is day 0
   return  weekday(now()); 
 }
 
@@ -165,7 +165,7 @@ void breakTime(time_t timeInput, tmElements_t &tm){
   time /= 60; // now it is hours
   tm.Hour = time % 24;
   time /= 24; // now it is days
-  tm.Wday = ((time + 4) % 7) ;  // Sunday is day 0
+  tm.Wday = ((time + 4) % 7);  // Sunday is day 0
   
   year = 0;  
   days = 0;

--- a/Time.cpp
+++ b/Time.cpp
@@ -165,7 +165,7 @@ void breakTime(time_t timeInput, tmElements_t &tm){
   time /= 60; // now it is hours
   tm.Hour = time % 24;
   time /= 24; // now it is days
-  tm.Wday = ((time + 4) % 7) + 1;  // Sunday is day 1 
+  tm.Wday = ((time + 4) % 7) ;  // Sunday is day 0
   
   year = 0;  
   days = 0;

--- a/TimeLib.h
+++ b/TimeLib.h
@@ -46,7 +46,7 @@ typedef struct  {
   uint8_t Second; 
   uint8_t Minute; 
   uint8_t Hour; 
-  uint8_t Wday;   // day of week, sunday is day 1
+  uint8_t Wday;   // day of week, sunday is day 0
   uint8_t Day;
   uint8_t Month; 
   uint8_t Year;   // offset from 1970; 
@@ -76,14 +76,14 @@ typedef time_t(*getExternalTime)();
 #define numberOfSeconds(_time_) (_time_ % SECS_PER_MIN)  
 #define numberOfMinutes(_time_) ((_time_ / SECS_PER_MIN) % SECS_PER_MIN) 
 #define numberOfHours(_time_) (( _time_% SECS_PER_DAY) / SECS_PER_HOUR)
-#define dayOfWeek(_time_)  ((( _time_ / SECS_PER_DAY + 4)  % DAYS_PER_WEEK)+1) // 1 = Sunday
+#define dayOfWeek(_time_)  ((( _time_ / SECS_PER_DAY + 4)  % DAYS_PER_WEEK)) // 0 = Sunday
 #define elapsedDays(_time_) ( _time_ / SECS_PER_DAY)  // this is number of days since Jan 1 1970
 #define elapsedSecsToday(_time_)  (_time_ % SECS_PER_DAY)   // the number of seconds since last midnight 
 // The following macros are used in calculating alarms and assume the clock is set to a date later than Jan 1 1971
 // Always set the correct time before settting alarms
 #define previousMidnight(_time_) (( _time_ / SECS_PER_DAY) * SECS_PER_DAY)  // time at the start of the given day
 #define nextMidnight(_time_) ( previousMidnight(_time_)  + SECS_PER_DAY )   // time at the end of the given day 
-#define elapsedSecsThisWeek(_time_)  (elapsedSecsToday(_time_) +  ((dayOfWeek(_time_)-1) * SECS_PER_DAY) )   // note that week starts on day 1
+#define elapsedSecsThisWeek(_time_)  (elapsedSecsToday(_time_) +  ((dayOfWeek(_time_)-1) * SECS_PER_DAY) )   // note that week starts on day 0
 #define previousSunday(_time_)  (_time_ - elapsedSecsThisWeek(_time_))      // time at the start of the week for the given time
 #define nextSunday(_time_) ( previousSunday(_time_)+SECS_PER_WEEK)          // time at the end of the week for the given time
 
@@ -110,7 +110,7 @@ int     second();          // the second now
 int     second(time_t t);  // the second for the given time
 int     day();             // the day now 
 int     day(time_t t);     // the day for the given time
-int     weekday();         // the weekday now (Sunday is day 1) 
+int     weekday();         // the weekday now (Sunday is day 0) 
 int     weekday(time_t t); // the weekday for the given time 
 int     month();           // the month now  (Jan is month 1)
 int     month(time_t t);   // the month for the given time


### PR DESCRIPTION
I changed the code such that it is consistent with the documentation. The documentation says that the function weekday() will return (0-6) where sunday is zero. This is currently not the case and it returns (1-7) where sunday is one.

This pull request just removes a +1 in two places and fixes a few comments to be consistent with that. However I am not sure whether this should be merged as this repo has 231 stars and 131 forks... (so apperantly a pretty popular one) and this is a breaking change. The other option would be to update the documentation to what the function actually does.

In every other framework I regularly use (.NET, ruby and javascript) the convention is to index Sunday at 0 though, so I think this library should follow that convention.