### PR TITLE
Delete Time.h

### DIFF
--- a/Time.h
+++ b/Time.h
@@ -1,1 +1,0 @@
-#include "TimeLib.h"


### PR DESCRIPTION
remove Time.h because it conflicts with time.h on file systems with case-insensitive filenames, e.g. Windows