### PR TITLE
strcpy_P not needed for ESP8266/2.5.0-beta2 sdk

### DIFF
--- a/DateStrings.cpp
+++ b/DateStrings.cpp
@@ -17,8 +17,10 @@
 #define PGM_P  const char *
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #define pgm_read_word(addr) (*(const unsigned char **)(addr))
+#ifndef ESP8266
 #ifndef strcpy_P
 #define strcpy_P(dest, src) strcpy((dest), (src))
+#endif
 #endif
 #endif
 #include <string.h> // for strcpy_P or strcpy


### PR DESCRIPTION
To solve #110 .