### PR TITLE
Fix bad URL in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Paul Stoffregen
 sentence=Timekeeping functionality for Arduino
 paragraph=Date and Time functions, with provisions to synchronize to external time sources like GPS and NTP (Internet).  This library is often used together with TimeAlarms and DS1307RTC.
 category=Timing
-url=http://playground.arduino.cc/code/time
+url=http://playground.arduino.cc/Code/Time/
 architectures=*
 


### PR DESCRIPTION
Use of incorrect case in the Arduino Playground URL resulted in a redirect to the Playground home page instead of the expected Time library page.

Partially fixes https://github.com/PaulStoffregen/Time/issues/123