### PR TITLE
Fix *ToTime_t macros to work with the Arduino compiler

### DIFF
--- a/TimeLib.h
+++ b/TimeLib.h
@@ -89,10 +89,10 @@ typedef time_t(*getExternalTime)();
 
 
 /* Useful Macros for converting elapsed time to a time_t */
-#define minutesToTime_t ((M)) ( (M) * SECS_PER_MIN)  
-#define hoursToTime_t   ((H)) ( (H) * SECS_PER_HOUR)  
-#define daysToTime_t    ((D)) ( (D) * SECS_PER_DAY) // fixed on Jul 22 2011
-#define weeksToTime_t   ((W)) ( (W) * SECS_PER_WEEK)   
+#define minutesToTime_t(M) ( (M) * SECS_PER_MIN)  
+#define hoursToTime_t(H) ( (H) * SECS_PER_HOUR)  
+#define daysToTime_t(D) ( (D) * SECS_PER_DAY) // fixed on Jul 22 2011
+#define weeksToTime_t(W) ( (W) * SECS_PER_WEEK)   
 
 /*============================================================================*/
 /*  time and date functions   */


### PR DESCRIPTION
The daysToTime_t (and all other similar macros) does not compile correctly on recent Arduino SDK.
Apparently the compiler require that there will be no space between the macro name and the (x) parameter definition.