### PR TITLE
Added includes to properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,6 @@ sentence=Timekeeping functionality for Arduino
 paragraph=Date and Time functions, with provisions to synchronize to external time sources like GPS and NTP (Internet).  This library is often used together with TimeAlarms and DS1307RTC.
 category=Timing
 url=http://playground.arduino.cc/Code/Time/
+includes=TimeLib.h
 architectures=*
 


### PR DESCRIPTION
The Arduino library.properties specification gives the `includes` entry:

* **includes - (available from Arduino IDE 1.6.10) (optional)** a comma separated list of files to be added to the sketch as #include <...> lines. This property is used with the "Include library" command in the Arduino IDE. If the includes property is missing, all the header files (.h) on the root source folder are included.

Adding this will prevent both Time.h and TimeLib.h from being included in the IDE with the include library menu option.