### PR TITLE
Modified now() to return timeNeedsSync if time is set and the sync …

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,7 +70,9 @@ adjustTime(adjustment);          // adjust system time by adding the adjustment 
 timeStatus();                    // indicates if time has been set and recently synchronized
                                  // returns one of the following enumerations:
 timeNotSet                       // the time has never been set, the clock started on Jan 1, 1970
-timeNeedsSync                    // the time had been set but a sync attempt did not succeed
+timeNeedsSync                    // the time had been set
+                                 // if setSyncProvider was called then a sync attempt did not succeed
+                                 // else the sync interval has passed since the last time sync
 timeSet                          // the time is set and is synced
 ```
 
@@ -119,6 +121,13 @@ illustrating how the library can be used with various time sources:
 - `TimeGPS` gets time from a GPS.
   This requires the TinyGPS library from Mikal Hart:
   <http://arduiniana.org/libraries/TinyGPS>
+
+- `TimeGPS_Neo` gets time from a GPS.
+  This requires the NeoGPS library from SlashDevin:
+  <https://github.com/SlashDevin/NeoGPS>
+  The example demonstrates how to set the time from the GPS when the time is not set
+  or the sync interval has lapsed. The Sync Interval is 300 seconds or 5 minutes by
+  default and may be changed by calling setSyncInterval(interval) where interval is seconds.
 
 ## Differences
 

--- a/Time.cpp
+++ b/Time.cpp
@@ -258,15 +258,15 @@ time_t now() {
 #endif
   }
   if (nextSyncTime <= sysTime) {
+    Status = (Status == timeNotSet) ?  timeNotSet : timeNeedsSync;
     if (getTimePtr != 0) {
       time_t t = getTimePtr();
       if (t != 0) {
         setTime(t);
-      } else {
-        nextSyncTime = sysTime + syncInterval;
-        Status = (Status == timeNotSet) ?  timeNotSet : timeNeedsSync;
+        Status = timeSet;
       }
     }
+    nextSyncTime = sysTime + syncInterval;
   }  
   return (time_t)sysTime;
 }

--- a/examples/TimeGPS_Neo/TimeGPS_Neo.ino
+++ b/examples/TimeGPS_Neo/TimeGPS_Neo.ino
@@ -1,0 +1,92 @@
+/*
+   TimeGPS_Neo.ino
+
+   Example written by Richard Teel with printDigits & digitalClockDisplay from TimeGPS example
+   Hardware used
+    Teensy 2.0 https://www.pjrc.com/store/teensy.html
+    Sparkfun GPS GP-735 https://www.sparkfun.com/products/13670
+
+   NOTE: The time remains in UTC. You may use adjustTime to change to local time.
+
+   Sample Output
+    ...\TimeGPS_Neo.ino: started
+    Time set from GPS to: 9-13-2021 23:51:22
+    Time set from GPS to: 9-13-2021 23:51:52
+    Time set from GPS to: 9-13-2021 23:52:22
+    Time set from GPS to: 9-13-2021 23:52:51
+    Time set from GPS to: 9-13-2021 23:53:22
+    Time set from GPS to: 9-13-2021 23:53:52
+    Time set from GPS to: 9-13-2021 23:54:22
+    Time set from GPS to: 9-13-2021 23:54:51
+
+*/
+
+#include <NMEAGPS.h>
+#include <GPSport.h>
+#include <TimeLib.h>
+
+/***********/
+/*   GPS   */
+/***********/
+NMEAGPS  gps; // This parses the GPS characters
+gps_fix  fix; // This holds on to the latest values
+
+// Debug function to print the date and time
+void printDigits(int digits) {
+  // utility function for digital clock display: prints preceding colon and leading 0
+  Serial.print(":");
+  if (digits < 10)
+    Serial.print('0');
+  Serial.print(digits);
+}
+
+void digitalClockDisplay() {
+  // digital clock display of the time
+  Serial.print(month());
+  Serial.print("-");
+  Serial.print(day());
+  Serial.print("-");
+  Serial.print(year());
+  Serial.print(" ");
+  Serial.print(hour());
+  printDigits(minute());
+  printDigits(second());
+  Serial.println();
+}
+
+void setup() {
+  Serial.begin(9600);
+
+  // Wait for a serial connection
+  while (!Serial)
+    ;
+
+  // Print the sketch file path and name
+  Serial.print(F(__FILE__));
+  Serial.println( F(": started") );
+
+  // For demonstration purposes, set the time sync interval to 30 seconds
+  // It is recommended to leave at the default 300 seconds
+  setSyncInterval(30);
+
+  // GPS
+  gpsPort.begin(9600);
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  while (gps.available( gpsPort )) {
+    fix = gps.read();
+  }
+
+  // Set the time
+  if (timeStatus() != timeSet) {
+    if (fix.valid.time && fix.valid.date) {
+      setTime(fix.dateTime.hours, fix.dateTime.minutes, fix.dateTime.seconds, fix.dateTime.date, fix.dateTime.month, fix.dateTime.full_year());
+      if (Serial) {
+        Serial.print(F("Time set from GPS to: "));
+        digitalClockDisplay();
+      }
+    }
+  }
+}


### PR DESCRIPTION
…interval elapsed even if the setSyncProvider was not called.

- Updated documentation
- Included example TimeGPS_Neo.ino to demonstrate updating time when GPS has a fix and the time is not set or sync interval has elapsed

I had commented earlier today on the PJRC forum that I would be submitting this pull request.
https://forum.pjrc.com/threads/68178-TimeLib-now()